### PR TITLE
feat: add dag-json support to treewalk splitter

### DIFF
--- a/lib/treewalk/splitter.js
+++ b/lib/treewalk/splitter.js
@@ -3,6 +3,7 @@ import { Block } from 'multiformats/block'
 import * as raw from 'multiformats/codecs/raw'
 import * as cbor from '@ipld/dag-cbor'
 import * as pb from '@ipld/dag-pb'
+import * as json from '@ipld/dag-json'
 
 /**
  * @typedef {{ decoders?: import('multiformats/codecs/interface').BlockDecoder<any, any>[] }} Options
@@ -24,7 +25,7 @@ export class TreewalkCarSplitter {
     this._reader = reader
     this._targetSize = targetSize
     /** @type {import('multiformats/codecs/interface').BlockDecoder<any, any>[]} */
-    this._decoders = [pb, raw, cbor, ...(options.decoders || [])]
+    this._decoders = [pb, raw, cbor, json, ...(options.decoders || [])]
   }
 
   async * cars () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "carbites",
       "version": "1.0.6",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^3.0.1",
         "@ipld/dag-cbor": "^6.0.3",
+        "@ipld/dag-json": "^9.0.1",
         "@ipld/dag-pb": "^2.0.2",
         "multiformats": "^9.0.4"
       },
@@ -133,6 +135,28 @@
       "dependencies": {
         "cborg": "^1.2.1",
         "multiformats": "^9.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-json": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-9.0.1.tgz",
+      "integrity": "sha512-dL5Xhrk0XXoq3lSsY2LNNraH2Nxx4nlgQwSarl2J3oir2jBDQEiBDW8bjgr30ni8/epdWDhXm5mdxat8dFWwGQ==",
+      "dependencies": {
+        "cborg": "^1.5.4",
+        "multiformats": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-json/node_modules/multiformats": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.2.tgz",
+      "integrity": "sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@ipld/dag-pb": {
@@ -1010,9 +1034,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.4.tgz",
-      "integrity": "sha512-w/sCTLy2k4AI6XbDMiaPsGc07bBAcX/It3VYQBwKJ5fvAAyUOXi5nC1wjW0OXIfY5ROkOGJCAUOR5AW1ykkiCQ==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.5.tgz",
+      "integrity": "sha512-fLBv8wmqtlXqy1Yu+pHzevAIkW6k2K0ZtMujNzWphLsA34vzzg9BHn+5GmZqOJkSA9V7EMKsWrf6K976c1QMjQ==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -5778,6 +5802,22 @@
         "multiformats": "^9.0.0"
       }
     },
+    "@ipld/dag-json": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-9.0.1.tgz",
+      "integrity": "sha512-dL5Xhrk0XXoq3lSsY2LNNraH2Nxx4nlgQwSarl2J3oir2jBDQEiBDW8bjgr30ni8/epdWDhXm5mdxat8dFWwGQ==",
+      "requires": {
+        "cborg": "^1.5.4",
+        "multiformats": "^10.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.2.tgz",
+          "integrity": "sha512-nJEHLFOYhO4L+aNApHhCnWqa31FyqAHv9Q77AhmwU3KsM2f1j7tuJpCk5ByZ33smzycNCpSG5klNIejIyfFx2A=="
+        }
+      }
+    },
     "@ipld/dag-pb": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.0.2.tgz",
@@ -6491,9 +6531,9 @@
       "dev": true
     },
     "cborg": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.4.tgz",
-      "integrity": "sha512-w/sCTLy2k4AI6XbDMiaPsGc07bBAcX/It3VYQBwKJ5fvAAyUOXi5nC1wjW0OXIfY5ROkOGJCAUOR5AW1ykkiCQ=="
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.5.tgz",
+      "integrity": "sha512-fLBv8wmqtlXqy1Yu+pHzevAIkW6k2K0ZtMujNzWphLsA34vzzg9BHn+5GmZqOJkSA9V7EMKsWrf6K976c1QMjQ=="
     },
     "chalk": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@ipld/car": "^3.0.1",
     "@ipld/dag-cbor": "^6.0.3",
+    "@ipld/dag-json": "^9.0.1",
     "@ipld/dag-pb": "^2.0.2",
     "multiformats": "^9.0.4"
   },


### PR DESCRIPTION
Closes #16.

@alanshaw I think this should be enough to support  `dag-json`.