### PR TITLE
feat!: dont use ipjs and add package.json exports[].types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 coverage
 dist
+/types
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@web-std/blob": "^2.1.0",
         "ava": "^3.15.0",
         "c8": "^7.7.2",
-        "ipjs": "^5.0.0",
         "ipld-garbage": "^4.0.1",
         "standard": "^16.0.3",
         "typescript": "^4.2.4"
@@ -230,15 +229,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@tgrajewski/rmtree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tgrajewski/rmtree/-/rmtree-1.0.1.tgz",
-      "integrity": "sha512-sbmprNcoyALNGlu/kCS55T9zBMi40OZ8eLaGGwOnEg0Pu40PqQI57yz2Cb99/Jq7PfCpLVSqg8lQoRF5NAyEmg==",
-      "dev": true,
-      "bin": {
-        "rmtree": "bin.js"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -1594,26 +1584,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "dev": true,
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
     "node_modules/eslint": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.13.0.tgz",
@@ -2291,12 +2261,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/esm-ast-to-cjs": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/esm-ast-to-cjs/-/esm-ast-to-cjs-0.0.2.tgz",
-      "integrity": "sha512-LG52tXjWthh4tXssCCYWbR6wb6yXlx98B9XGYnZiRufA7RM8ej11KxclSGb9qKvDu/cp37F1pbOyTkr5WcJUkA==",
-      "dev": true
-    },
     "node_modules/espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -2892,23 +2856,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ipjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ipjs/-/ipjs-5.0.0.tgz",
-      "integrity": "sha512-658jpaZuR7TH4rlc6rEKY73a83B+IonF6ojsSAqPEfyTDHl5As3BnvnijlEiVYyLkXG1y1JV3v8p0/F37EuaVQ==",
-      "dev": true,
-      "dependencies": {
-        "@tgrajewski/rmtree": "^1.0.1",
-        "acorn": "^8.0.5",
-        "escodegen": "^2.0.0",
-        "esm-ast-to-cjs": "^0.0.2",
-        "rollup": "^2.38.1",
-        "rollup-plugin-preserve-shebangs": "^0.2.0"
-      },
-      "bin": {
-        "ipjs": "cli.js"
-      }
-    },
     "node_modules/ipld-garbage": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/ipld-garbage/-/ipld-garbage-4.0.1.tgz",
@@ -3403,19 +3350,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -3586,15 +3520,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.4"
       }
     },
     "node_modules/make-dir": {
@@ -3891,23 +3816,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/ora": {
@@ -4354,15 +4262,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -4624,30 +4523,6 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/rollup": {
-      "version": "2.52.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.1.tgz",
-      "integrity": "sha512-/SPqz8UGnp4P1hq6wc9gdTqA2bXQXGx13TtoL03GBm6qGRI6Hm3p4Io7GeiHNLl0BsQAne1JNYY+q/apcY933w==",
-      "dev": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/rollup-plugin-preserve-shebangs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-preserve-shebangs/-/rollup-plugin-preserve-shebangs-0.2.0.tgz",
-      "integrity": "sha512-OEyTIfZwUJ7yUAVAbegac/bNvp1WJzgZcQNCFprWX42wwwOqlJwrev9lUmzZdYVgCWct+03xUPvZg4RfgkM9oQ==",
-      "dev": true,
-      "dependencies": {
-        "magic-string": "^0.25.7"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4829,12 +4704,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -5233,18 +5102,6 @@
         "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -5872,12 +5729,6 @@
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
-    },
-    "@tgrajewski/rmtree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tgrajewski/rmtree/-/rmtree-1.0.1.tgz",
-      "integrity": "sha512-sbmprNcoyALNGlu/kCS55T9zBMi40OZ8eLaGGwOnEg0Pu40PqQI57yz2Cb99/Jq7PfCpLVSqg8lQoRF5NAyEmg==",
-      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -6988,19 +6839,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "dev": true,
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      }
-    },
     "eslint": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.13.0.tgz",
@@ -7553,12 +7391,6 @@
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
     },
-    "esm-ast-to-cjs": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/esm-ast-to-cjs/-/esm-ast-to-cjs-0.0.2.tgz",
-      "integrity": "sha512-LG52tXjWthh4tXssCCYWbR6wb6yXlx98B9XGYnZiRufA7RM8ej11KxclSGb9qKvDu/cp37F1pbOyTkr5WcJUkA==",
-      "dev": true
-    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -8029,20 +7861,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "ipjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ipjs/-/ipjs-5.0.0.tgz",
-      "integrity": "sha512-658jpaZuR7TH4rlc6rEKY73a83B+IonF6ojsSAqPEfyTDHl5As3BnvnijlEiVYyLkXG1y1JV3v8p0/F37EuaVQ==",
-      "dev": true,
-      "requires": {
-        "@tgrajewski/rmtree": "^1.0.1",
-        "acorn": "^8.0.5",
-        "escodegen": "^2.0.0",
-        "esm-ast-to-cjs": "^0.0.2",
-        "rollup": "^2.38.1",
-        "rollup-plugin-preserve-shebangs": "^0.2.0"
-      }
-    },
     "ipld-garbage": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/ipld-garbage/-/ipld-garbage-4.0.1.tgz",
@@ -8431,16 +8249,6 @@
         "package-json": "^6.3.0"
       }
     },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      }
-    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -8576,15 +8384,6 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
-      }
-    },
-    "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -8818,20 +8617,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
-      "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
       }
     },
     "ora": {
@@ -9172,12 +8957,6 @@
         "irregular-plurals": "^3.2.0"
       }
     },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -9386,24 +9165,6 @@
         "glob": "^7.1.3"
       }
     },
-    "rollup": {
-      "version": "2.52.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.1.tgz",
-      "integrity": "sha512-/SPqz8UGnp4P1hq6wc9gdTqA2bXQXGx13TtoL03GBm6qGRI6Hm3p4Io7GeiHNLl0BsQAne1JNYY+q/apcY933w==",
-      "dev": true,
-      "requires": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "rollup-plugin-preserve-shebangs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-preserve-shebangs/-/rollup-plugin-preserve-shebangs-0.2.0.tgz",
-      "integrity": "sha512-OEyTIfZwUJ7yUAVAbegac/bNvp1WJzgZcQNCFprWX42wwwOqlJwrev9lUmzZdYVgCWct+03xUPvZg4RfgkM9oQ==",
-      "dev": true,
-      "requires": {
-        "magic-string": "^0.25.7"
-      }
-    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9552,12 +9313,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -9884,15 +9639,6 @@
         "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
-      }
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2"
       }
     },
     "typedarray-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,10 @@
   "types": "./types/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "npm run build:js && npm run build:types",
-    "build:js": "ipjs build --tests --main && npm run build:copy",
-    "build:copy": "cp -a tsconfig.json lib test dist/ ",
-    "build:types": "npm run build:copy && cd dist && tsc --build",
-    "test": "npm run lint && npm run test:node && npm run test:cjs",
+    "build": "npm run build:types",
+    "build:types": "tsc --build",
+    "test": "npm run lint && npm run test:node",
     "test:node": "ava --verbose 'test/*.spec.js'",
-    "test:cjs": "npm run build:js && ava --verbose dist/cjs/node-test/*.spec.js",
     "coverage": "c8 npm run test",
     "lint": "standard"
   },
@@ -29,7 +26,6 @@
     "@web-std/blob": "^2.1.0",
     "ava": "^3.15.0",
     "c8": "^7.7.2",
-    "ipjs": "^5.0.0",
     "ipld-garbage": "^4.0.1",
     "standard": "^16.0.3",
     "typescript": "^4.2.4"
@@ -41,16 +37,20 @@
   },
   "exports": {
     ".": {
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "types": "./types/index.d.ts"
     },
     "./rooted": {
-      "import": "./lib/rooted/index.js"
+      "import": "./lib/rooted/index.js",
+      "types": "./types/rooted/index.d.ts"
     },
     "./simple": {
-      "import": "./lib/simple/index.js"
+      "import": "./lib/simple/index.js",
+      "types": "./types/simple/index.d.ts"
     },
     "./treewalk": {
-      "import": "./lib/treewalk/index.js"
+      "import": "./lib/treewalk/index.js",
+      "types": "./types/treewalk/index.d.ts"
     }
   },
   "typesVersions": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,8 +48,7 @@
     "esm",
     "cjs",
     "test",
-    "dist",
-    "./**/*.d.ts"
+    "types"
   ],
   "compileOnSave": false
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,9 @@
     "node_modules",
     "esm",
     "cjs",
-    "test"
+    "test",
+    "dist",
+    "./**/*.d.ts"
   ],
   "compileOnSave": false
 }


### PR DESCRIPTION
Motivation:
* I was getting errors due to no exports[].types in package.json
* I couldn't get it all happy while also keeping `ipjs` e.g. because `ipjs` was trying to build `./dist` and/or `./types` and I couldn't find a way to ignore those. Hope its ok to drop ipjs.

Notes:
* breaking change since it changes how the npm package is laid out and could cause hiccups for dependers